### PR TITLE
repair unit testing

### DIFF
--- a/src/test/java/org/springframework/data/mybatis/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/mybatis/repository/UserRepositoryTests.java
@@ -71,13 +71,10 @@ public class UserRepositoryTests {
         thirdUser.setAge(43);
         fourthUser = new User("kevin", "raymond", "no@gmail.com");
         fourthUser.setAge(31);
-        adminRole = new Role("admin");
 
     }
 
     protected void flushTestUsers() {
-
-        roleRepository.save(adminRole);
 
         firstUser = repository.save(firstUser);
         secondUser = repository.save(secondUser);


### PR DESCRIPTION
- Unused removed "ROLE_admin" repair expected in RoleSimpleRepositoryTests

__Before__
```bash
Failed tests: 
  RoleSimpleRepositoryTests.testCount:135 expected:<4> but was:<5>
  RoleSimpleRepositoryTests.testFindAll:114 expected:<4> but was:<5>
  RoleSimpleRepositoryTests.testFindByPage:184 expected:<4> but was:<5>
  RoleSimpleRepositoryTests.testFindBySort:175 expected:<ROLE_assistant> but was:<ROLE_admin>

Tests run: 82, Failures: 4, Errors: 4, Skipped: 0
```

__After__
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 11.376 s
[INFO] Finished at: 2016-12-05T14:39:30+07:00
[INFO] Final Memory: 24M/544M
[INFO] ------------------------------------------------------------------------
```