### PR TITLE
Optimize `AuditingInterceptor` to support auditing iterable objects.

### DIFF
--- a/spring-data-mybatis/src/main/java/org/springframework/data/mybatis/mapping/model/JoinTable.java
+++ b/spring-data-mybatis/src/main/java/org/springframework/data/mybatis/mapping/model/JoinTable.java
@@ -29,13 +29,16 @@ public class JoinTable extends Connector {
 	private static final long serialVersionUID = 6291689921380485728L;
 
 	private Table table;
+
 	private List<JoinColumn> locals = new LinkedList<>();
+
 	private List<JoinColumn> foreigns = new LinkedList<>();
 
-	public void addLocal(JoinColumn joinColumn){
+	public void addLocal(JoinColumn joinColumn) {
 		this.locals.add(joinColumn);
 	}
-	public void addForeign(JoinColumn joinColumn){
+
+	public void addForeign(JoinColumn joinColumn) {
 		this.foreigns.add(joinColumn);
 	}
 
@@ -51,126 +54,130 @@ public class JoinTable extends Connector {
 		return this.locals;
 	}
 
-
-
 	public List<JoinColumn> getForeigns() {
 		return this.foreigns;
 	}
 
-
-
-	//	private final MybatisPersistentProperty property;
-//
-//	private final Domain localDomain;
-//
-//	private final Domain foreignDomain;
-//
-//	private final Table table;
-//
-//	private final List<JoinColumn> localJoinColumns = new LinkedList<>();
-//
-//	private final List<JoinColumn> foreignJoinColumns = new LinkedList<>();
-//
-//	public JoinTable(MybatisPersistentProperty property, Domain localDomain, Domain foreignDomain) {
-//		this.property = property;
-//		this.localDomain = localDomain;
-//		this.foreignDomain = foreignDomain;
-//
-//		String schema = null;
-//		String catalog = null;
-//		String name = null;
-//		if (property.isAnnotationPresent(javax.persistence.JoinTable.class)) {
-//			javax.persistence.JoinTable joinTableAnn = property
-//					.getRequiredAnnotation(javax.persistence.JoinTable.class);
-//			schema = joinTableAnn.schema();
-//			catalog = joinTableAnn.catalog();
-//			name = joinTableAnn.name();
-//
-//			if (null != joinTableAnn.joinColumns() && joinTableAnn.joinColumns().length > 0) {
-//				for (javax.persistence.JoinColumn joinColumn : joinTableAnn.joinColumns()) {
-//					this.localJoinColumns
-//							.add(this.processJoinColumn(false, joinColumn.name(), joinColumn.referencedColumnName()));
-//				}
-//			}
-//			if (null != joinTableAnn.inverseJoinColumns() && joinTableAnn.inverseJoinColumns().length > 0) {
-//				for (javax.persistence.JoinColumn joinColumn : joinTableAnn.inverseJoinColumns()) {
-//					this.foreignJoinColumns
-//							.add(this.processJoinColumn(true, joinColumn.name(), joinColumn.referencedColumnName()));
-//				}
-//			}
-//		}
-//
-//		if (this.localJoinColumns.isEmpty()) {
-//			this.localJoinColumns.add(this.processJoinColumn(false, null, null));
-//		}
-//
-//		if (this.foreignJoinColumns.isEmpty()) {
-//			this.foreignJoinColumns.add(this.processJoinColumn(true, null, null));
-//		}
-//
-//		if (StringUtils.isEmpty(name)) {
-//			name = localDomain.getTable().getName().getText() + '_' + foreignDomain.getTable().getName().getText();
-//		}
-//		this.table = new Table(schema, catalog, name);
-//
-//	}
-//
-//	public String getTableAlias() {
-//		return this.table.getName().getText() + '_' + this.property.getName();
-//	}
-//
-//	private JoinColumn processJoinColumn(boolean referenced, String localColumnName, String foreignColumnName) {
-//		Domain domain = referenced ? this.foreignDomain : this.localDomain;
-//		Column local;
-//		Column foreign;
-//		if (StringUtils.isEmpty(foreignColumnName)) {
-//			PrimaryKey foreignPrimaryKey = domain.getPrimaryKey();
-//			if (null == foreignPrimaryKey || foreignPrimaryKey.isComposited()) {
-//				throw new MappingException(
-//						"Could not find referenced column [" + foreignColumnName + "] in " + this.property);
-//			}
-//			foreign = foreignPrimaryKey.getColumns().values().stream().findFirst().get();
-//		}
-//		else {
-//			foreign = domain.findColumn(Identifier.toIdentifier(foreignColumnName));
-//		}
-//
-//		if (null == foreign) {
-//			throw new MappingException("Count not find referenced column in " + this.property);
-//		}
-//
-//		if (StringUtils.isEmpty(localColumnName)) {
-//			localColumnName = domain.getTable().getName().getText() + '_' + foreign.getName().getText();
-//		}
-//		Identifier localIdentifier = Identifier.toIdentifier(localColumnName);
-//
-//		local = new Column(domain, foreign.getProperty());
-//		local.setName(localIdentifier);
-//		return new JoinColumn(local, foreign);
-//	}
-//
-//	public MybatisPersistentProperty getProperty() {
-//		return this.property;
-//	}
-//
-//	public Domain getLocalDomain() {
-//		return this.localDomain;
-//	}
-//
-//	public Domain getForeignDomain() {
-//		return this.foreignDomain;
-//	}
-//
-//	public Table getTable() {
-//		return this.table;
-//	}
-//
-//	public List<JoinColumn> getLocalJoinColumns() {
-//		return this.localJoinColumns;
-//	}
-//
-//	public List<JoinColumn> getForeignJoinColumns() {
-//		return this.foreignJoinColumns;
-//	}
+	// private final MybatisPersistentProperty property;
+	//
+	// private final Domain localDomain;
+	//
+	// private final Domain foreignDomain;
+	//
+	// private final Table table;
+	//
+	// private final List<JoinColumn> localJoinColumns = new LinkedList<>();
+	//
+	// private final List<JoinColumn> foreignJoinColumns = new LinkedList<>();
+	//
+	// public JoinTable(MybatisPersistentProperty property, Domain localDomain, Domain
+	// foreignDomain) {
+	// this.property = property;
+	// this.localDomain = localDomain;
+	// this.foreignDomain = foreignDomain;
+	//
+	// String schema = null;
+	// String catalog = null;
+	// String name = null;
+	// if (property.isAnnotationPresent(javax.persistence.JoinTable.class)) {
+	// javax.persistence.JoinTable joinTableAnn = property
+	// .getRequiredAnnotation(javax.persistence.JoinTable.class);
+	// schema = joinTableAnn.schema();
+	// catalog = joinTableAnn.catalog();
+	// name = joinTableAnn.name();
+	//
+	// if (null != joinTableAnn.joinColumns() && joinTableAnn.joinColumns().length > 0) {
+	// for (javax.persistence.JoinColumn joinColumn : joinTableAnn.joinColumns()) {
+	// this.localJoinColumns
+	// .add(this.processJoinColumn(false, joinColumn.name(),
+	// joinColumn.referencedColumnName()));
+	// }
+	// }
+	// if (null != joinTableAnn.inverseJoinColumns() &&
+	// joinTableAnn.inverseJoinColumns().length > 0) {
+	// for (javax.persistence.JoinColumn joinColumn : joinTableAnn.inverseJoinColumns()) {
+	// this.foreignJoinColumns
+	// .add(this.processJoinColumn(true, joinColumn.name(),
+	// joinColumn.referencedColumnName()));
+	// }
+	// }
+	// }
+	//
+	// if (this.localJoinColumns.isEmpty()) {
+	// this.localJoinColumns.add(this.processJoinColumn(false, null, null));
+	// }
+	//
+	// if (this.foreignJoinColumns.isEmpty()) {
+	// this.foreignJoinColumns.add(this.processJoinColumn(true, null, null));
+	// }
+	//
+	// if (StringUtils.isEmpty(name)) {
+	// name = localDomain.getTable().getName().getText() + '_' +
+	// foreignDomain.getTable().getName().getText();
+	// }
+	// this.table = new Table(schema, catalog, name);
+	//
+	// }
+	//
+	// public String getTableAlias() {
+	// return this.table.getName().getText() + '_' + this.property.getName();
+	// }
+	//
+	// private JoinColumn processJoinColumn(boolean referenced, String localColumnName,
+	// String foreignColumnName) {
+	// Domain domain = referenced ? this.foreignDomain : this.localDomain;
+	// Column local;
+	// Column foreign;
+	// if (StringUtils.isEmpty(foreignColumnName)) {
+	// PrimaryKey foreignPrimaryKey = domain.getPrimaryKey();
+	// if (null == foreignPrimaryKey || foreignPrimaryKey.isComposited()) {
+	// throw new MappingException(
+	// "Could not find referenced column [" + foreignColumnName + "] in " +
+	// this.property);
+	// }
+	// foreign = foreignPrimaryKey.getColumns().values().stream().findFirst().get();
+	// }
+	// else {
+	// foreign = domain.findColumn(Identifier.toIdentifier(foreignColumnName));
+	// }
+	//
+	// if (null == foreign) {
+	// throw new MappingException("Count not find referenced column in " + this.property);
+	// }
+	//
+	// if (StringUtils.isEmpty(localColumnName)) {
+	// localColumnName = domain.getTable().getName().getText() + '_' +
+	// foreign.getName().getText();
+	// }
+	// Identifier localIdentifier = Identifier.toIdentifier(localColumnName);
+	//
+	// local = new Column(domain, foreign.getProperty());
+	// local.setName(localIdentifier);
+	// return new JoinColumn(local, foreign);
+	// }
+	//
+	// public MybatisPersistentProperty getProperty() {
+	// return this.property;
+	// }
+	//
+	// public Domain getLocalDomain() {
+	// return this.localDomain;
+	// }
+	//
+	// public Domain getForeignDomain() {
+	// return this.foreignDomain;
+	// }
+	//
+	// public Table getTable() {
+	// return this.table;
+	// }
+	//
+	// public List<JoinColumn> getLocalJoinColumns() {
+	// return this.localJoinColumns;
+	// }
+	//
+	// public List<JoinColumn> getForeignJoinColumns() {
+	// return this.foreignJoinColumns;
+	// }
 
 }

--- a/spring-data-mybatis/src/main/java/org/springframework/data/mybatis/precompiler/SimpleMybatisPrecompiler.java
+++ b/spring-data-mybatis/src/main/java/org/springframework/data/mybatis/precompiler/SimpleMybatisPrecompiler.java
@@ -142,29 +142,34 @@ public class SimpleMybatisPrecompiler extends AbstractMybatisPrecompiler {
 
 	private void associativeTableStatement() {
 
-//		this.domain.getAssociations().entrySet().stream().filter(entry -> entry.getValue().isManyToMany())
-//				.forEach(entry -> {
-//					ManyToManyAssociation association = (ManyToManyAssociation) entry.getValue();
-//					String namespace = "associative." + association.getJoinTable().getTable().toString();
-//					Map<String, Object> scopes = new HashMap<>();
-//					scopes.put("association", association);
-//					if (!this.checkStatement(namespace, ResidentStatementName.INSERT)) {
-//						scopes.put(SCOPE_STATEMENT_NAME, ResidentStatementName.INSERT);
-//						this.compileMapper("associative/" + namespace.replace('.', '/') + "/insert", namespace,
-//								Collections.singletonList(this.render("AssociativeInsert", scopes)));
-//					}
-//
-//					if (!this.checkStatement(namespace, ResidentStatementName.UPDATE)) {
-//						scopes.put(SCOPE_STATEMENT_NAME, ResidentStatementName.UPDATE);
-//						this.compileMapper("associative/" + namespace.replace('.', '/') + "/update", namespace,
-//								Collections.singletonList(this.render("AssociativeUpdate", scopes)));
-//					}
-//					if (!this.checkStatement(namespace, ResidentStatementName.DELETE)) {
-//						scopes.put(SCOPE_STATEMENT_NAME, ResidentStatementName.DELETE);
-//						this.compileMapper("associative/" + namespace.replace('.', '/') + "/delete", namespace,
-//								Collections.singletonList(this.render("AssociativeDelete", scopes)));
-//					}
-//				});
+		// this.domain.getAssociations().entrySet().stream().filter(entry ->
+		// entry.getValue().isManyToMany())
+		// .forEach(entry -> {
+		// ManyToManyAssociation association = (ManyToManyAssociation) entry.getValue();
+		// String namespace = "associative." +
+		// association.getJoinTable().getTable().toString();
+		// Map<String, Object> scopes = new HashMap<>();
+		// scopes.put("association", association);
+		// if (!this.checkStatement(namespace, ResidentStatementName.INSERT)) {
+		// scopes.put(SCOPE_STATEMENT_NAME, ResidentStatementName.INSERT);
+		// this.compileMapper("associative/" + namespace.replace('.', '/') + "/insert",
+		// namespace,
+		// Collections.singletonList(this.render("AssociativeInsert", scopes)));
+		// }
+		//
+		// if (!this.checkStatement(namespace, ResidentStatementName.UPDATE)) {
+		// scopes.put(SCOPE_STATEMENT_NAME, ResidentStatementName.UPDATE);
+		// this.compileMapper("associative/" + namespace.replace('.', '/') + "/update",
+		// namespace,
+		// Collections.singletonList(this.render("AssociativeUpdate", scopes)));
+		// }
+		// if (!this.checkStatement(namespace, ResidentStatementName.DELETE)) {
+		// scopes.put(SCOPE_STATEMENT_NAME, ResidentStatementName.DELETE);
+		// this.compileMapper("associative/" + namespace.replace('.', '/') + "/delete",
+		// namespace,
+		// Collections.singletonList(this.render("AssociativeDelete", scopes)));
+		// }
+		// });
 
 	}
 

--- a/spring-data-mybatis/src/test/java/org/springframework/data/mybatis/domain/sample/Role.java
+++ b/spring-data-mybatis/src/test/java/org/springframework/data/mybatis/domain/sample/Role.java
@@ -31,7 +31,7 @@ import org.springframework.data.mybatis.domain.AbstractPersistable;
  * @author JARVIS SONG
  */
 @Entity
-//@Table(name = "role")
+// @Table(name = "role")
 @Data
 @NoArgsConstructor
 public class Role extends AbstractPersistable<Long> {


### PR DESCRIPTION
Resolves #119, resolves #208 

1. Audit support is provided for parameters with `@Param` annotation attached.
2. Optimize `AuditingInterceptor` to support auditing iterable objects.

I don't have enough energy to review all the code in this library, so I only modified the parts that I think affect the functions I need. If there is any problem, please leave a comment.

Thank you for your efforts, it's a great library.

